### PR TITLE
support DateTime, Date and Time

### DIFF
--- a/lib/api_matchers/core/find_in_json.rb
+++ b/lib/api_matchers/core/find_in_json.rb
@@ -12,7 +12,7 @@ module APIMatchers
         expected_value = options.fetch(:value) if options.has_key? :value
         @json.each do |key, value|
           if key == expected_key
-            if expected_value.present?
+            unless expected_value.nil?
               if expected_value.is_a? DateTime or expected_value.is_a? Date
                   expected_value = expected_value.to_s
               elsif expected_value.is_a? Time
@@ -20,7 +20,7 @@ module APIMatchers
               end
             end
             
-            if value == expected_value or ! expected_value.present?
+            if value == expected_value or expected_value.nil?
               return value
             end
           end

--- a/lib/api_matchers/response_body/have_json_node.rb
+++ b/lib/api_matchers/response_body/have_json_node.rb
@@ -15,7 +15,7 @@ module APIMatchers
         begin
           options = {}
           options[:node] = @expected_node.to_s
-          if @with_value.present?
+          unless @with_value.nil?
             options[:value] = @with_value
           end
 

--- a/spec/api_matchers/response_body/have_json_node_spec.rb
+++ b/spec/api_matchers/response_body/have_json_node_spec.rb
@@ -21,8 +21,20 @@ describe APIMatchers::ResponseBody::HaveJsonNode do
         { :number => 1 }.to_json.should have_json_node(:number).with(1)
       end
 
-      it "should pass when the expected key exist with the expected value (as boolean)" do
+      it "should pass when the expected key exist with the expected value (as boolean, true)" do
         { :number => true }.to_json.should have_json_node(:number).with(true)
+      end
+
+      it "should pass when the expected key exist with the expected value (as boolean, false)" do
+        { :number => false }.to_json.should have_json_node(:number).with(false)
+      end
+
+      it "should pass when the expected key exist but the expected value is wrong (as boolean, true)" do
+        { :number => true }.to_json.should_not have_json_node(:number).with(false)
+      end
+
+      it "should pass when the expected key exist but the expected value is wrong (as boolean, false)" do
+        { :number => false }.to_json.should_not have_json_node(:number).with(true)
       end
 
       it "should pass when the expected key exists with the expected value (as DateTime)" do


### PR DESCRIPTION
specifically handle DateTime, Date and Time as strings so that hidden values (at least in the case of DateTime and Time) don't force two equal date/time strings to be unequal (e.g. usec). 
