### PR TITLE
Change gemspec to use rspec 2.99beta1 in a new branch

### DIFF
--- a/api_matchers.gemspec
+++ b/api_matchers.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = APIMatchers::VERSION
 
-  gem.add_dependency 'rspec', '>= 2.10.0'
+  gem.add_dependency 'rspec', ">= 2.99.0.beta1"
   gem.add_dependency 'activesupport', '>= 3.2.5'
   gem.add_dependency 'nokogiri', '>= 1.5.2'
 end


### PR DESCRIPTION
I am testing my application against rspec 2.99 so that I can prepare for the release of 3.0. It would be great to create a new branch of api_matchers which I can use against this version.
