### PR TITLE
Add #description method to Header and HTTP Status Code matchers

### DIFF
--- a/lib/api_matchers/headers/be_json.rb
+++ b/lib/api_matchers/headers/be_json.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected to not be a JSON response. Got: '#{expected_content_type}'.}
       end
 
+      def description
+        "be in JSON"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/headers/be_xml.rb
+++ b/lib/api_matchers/headers/be_xml.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected to not be a XML response. Got: '#{expected_content_type}'.}
       end
 
+      def description
+        "be in XML"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/be_bad_request.rb
+++ b/lib/api_matchers/http_status_code/be_bad_request.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be a Bad Request with the status '400'.}
       end
 
+      def description
+        "be a Bad Request with the status '400'"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/be_internal_server_error.rb
+++ b/lib/api_matchers/http_status_code/be_internal_server_error.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be Internal Server Error.}
       end
 
+      def description
+        "be Internal Server Error with the status '500'"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/be_not_found.rb
+++ b/lib/api_matchers/http_status_code/be_not_found.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be Not Found with the status '404'.}
       end
 
+      def description
+        "be Not Found with the status '404'"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/be_ok.rb
+++ b/lib/api_matchers/http_status_code/be_ok.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be ok with the status '200'.}
       end
 
+      def description
+        "be ok"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/be_ok.rb
+++ b/lib/api_matchers/http_status_code/be_ok.rb
@@ -14,7 +14,7 @@ module APIMatchers
       end
 
       def description
-        "be ok"
+        "be ok with the status '200'"
       end
 
       # RSpec 2 compatibility:

--- a/lib/api_matchers/http_status_code/be_unauthorized.rb
+++ b/lib/api_matchers/http_status_code/be_unauthorized.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be Unauthorized.}
       end
 
+      def description
+        "be Unauthorized with the status '401'"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/be_unprocessable_entity.rb
+++ b/lib/api_matchers/http_status_code/be_unprocessable_entity.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be Unprocessable entity with the status '#{expected_status_code}'.}
       end
 
+      def description
+        "be Unprocessable entity with the status '422'"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated

--- a/lib/api_matchers/http_status_code/create_resource.rb
+++ b/lib/api_matchers/http_status_code/create_resource.rb
@@ -13,6 +13,10 @@ module APIMatchers
         %Q{expected that '#{@http_status_code}' to NOT be Created Resource.}
       end
 
+      def description
+        "be Created Resource with the status '201'"
+      end
+
       # RSpec 2 compatibility:
       alias_method :failure_message_for_should, :failure_message
       alias_method :failure_message_for_should_not, :failure_message_when_negated


### PR DESCRIPTION
I'm using some of the matchers in this way on my tests:

it { expect(response).to be_ok }
it { expect(response).to be_in_json }

And RSPEC shows a big warning message in the failures saying that the matcher didn't had a #description method, nor I had a String in my test.
I just added the #description methods to Header and HTTP Status Code matchers becauses I thought that those are the ones that would be used in the way showed above.