### PR TITLE
Upgrade Nokogiri from 1.6.6.2 to 1.6.6.4 due to vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    api_matchers (0.6.1)
+    api_matchers (0.6.2)
       activesupport (>= 3.2.5)
-      nokogiri (>= 1.5.2)
+      nokogiri (~> 1.6.6.4)
       rspec (>= 3.1)
 
 GEM
@@ -20,7 +20,7 @@ GEM
     json (1.8.3)
     mini_portile (0.6.2)
     minitest (5.7.0)
-    nokogiri (1.6.6.2)
+    nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
@@ -44,3 +44,6 @@ PLATFORMS
 
 DEPENDENCIES
   api_matchers!
+
+BUNDLED WITH
+   1.10.6

--- a/api_matchers.gemspec
+++ b/api_matchers.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency 'rspec', '>= 3.1'
   gem.add_dependency 'activesupport', '>= 3.2.5'
-  gem.add_dependency 'nokogiri', '>= 1.5.2'
+  gem.add_dependency 'nokogiri', '~> 1.6.6.4'
 end


### PR DESCRIPTION
https://isitvulnerable.com/vulns/565780b7-c415-4079-a9f2-d5872317e76c
