### PR TITLE
Fix CI: disable stale bundler cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,10 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: true
+          bundler-cache: false
+
+      - name: Install dependencies
+        run: bundle install
 
       - name: Run tests
         run: bundle exec rspec


### PR DESCRIPTION
The bundler cache contained an old Gemfile.lock with only macOS platforms (arm64-darwin, x86_64-darwin), causing CI to fail on Linux runners.

Since Gemfile.lock is no longer tracked, disable bundler-cache and run bundle install explicitly.